### PR TITLE
Keep mute state from getting out of sync with reality

### DIFF
--- a/AlsaMixer.app/AMixer/AChannel.cc
+++ b/AlsaMixer.app/AMixer/AChannel.cc
@@ -35,6 +35,9 @@ void AChannel::setVolume(long value) {
 bool AChannel::isMuted() {
   int val;
 
+  if (!snd_mixer_selem_has_playback_switch(aItem->aElem)) {
+	  return (false); /* can't be muted? isn't muted. */
+  }
   snd_mixer_selem_get_playback_switch(aItem->aElem, (SNDCHID_T) id, &val);
 
   return (! (bool) val);

--- a/AlsaMixer.app/Mixer.cc
+++ b/AlsaMixer.app/Mixer.cc
@@ -464,8 +464,8 @@ void Mixer::setVolume(int button, int volume)
 
 void Mixer::toggleMute(int button)
 {
-  mVolumeMute[button] = !mVolumeMute[button];
   aMixer->itemToggleMute(button);
+  mVolumeMute[button] = aMixer->itemIsMuted(button);
   setButtonType(button);
 }
 


### PR DESCRIPTION
My hardware doesn't have a mute toggle on all its channels, so AlsaMixer really oughtn't indicate that it's muted something it can't.

Additionally, there is (was, before this patch) racey behavior between AlsaMixer polling the mixer device and the mVolumeMute copy of the mute state; by telling it to toggle the status and then setting the value according to what it reads back we avoid that.

Unrelatedly, my own local build does away with the status light on bottom altogether, but that requires losing middle-click-to-execute support, so may not be worth sharing.
