### PR TITLE
Fix error message spam when no player is running

### DIFF
--- a/wmusic/src/wmusic.c
+++ b/wmusic/src/wmusic.c
@@ -633,9 +633,11 @@ void DrawArrow(void)
 void DrawVolume(void)
 {
 		int volume;
-		double volume_double;
+		double volume_double = 0.0;
 
-		g_object_get(player, "volume", &volume_double, NULL);
+		if (player)
+			g_object_get(player, "volume", &volume_double, NULL);
+
 		volume = (int)(36 * volume_double);
 		if (volume > 36)
 			volume = 36;


### PR DESCRIPTION
```
[…]
Oct 04 19:18:10 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:10 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:10 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:11 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:12 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:12 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:12 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
Oct 04 19:18:12 pc wmusic[9784]: g_object_get: assertion 'G_IS_OBJECT (object)' failed
[…]
```
This patch fixes the above, which makes reading session logs much easier.