### PR TITLE
Update URL for wminfo dockapp

### DIFF
--- a/_posts/1970-01-01-wminfo.md
+++ b/_posts/1970-01-01-wminfo.md
@@ -3,7 +3,7 @@ layout: dockapp
 title: wminfo
 permalink: wminfo
 hosted: 0
-website: http://linux-bsd-unix.strefa.pl/index.en.html
+website: https://github.com/gapan/wminfo
 dockapps: 367
 images:
  - wminfo-00-linuxquestions.gif


### PR DESCRIPTION
The old wminfo homepage doesn't exist anymore. I have uploaded the
latest source that I could find on my github (along with any older
releases I could find) and released a new version with new features.