### PR TITLE
libdockapp: Don't leak value in XTextProperty

### DIFF
--- a/libdockapp/src/damain.c
+++ b/libdockapp/src/damain.c
@@ -175,6 +175,7 @@ DACreateIcon(char *name, unsigned width, unsigned height, int argc, char **argv)
 		printf("%s: can't allocate window name.\n",
 			_daContext->programName), exit(1);
 	XSetWMName(DADisplay, DALeader, &window_name);
+	XFree(window_name.value);
 
 	/* Set WMHints */
 	wmHints = XAllocWMHints();


### PR DESCRIPTION
Quote from XStringListToTextProperty(3): 'To free the storage for the value field, use XFree.'

Signed-off-by: Thomas Egerer <thomas.egerer@port22.eu>