### PR TITLE
Make AddMouseRegion's index unsigned

### DIFF
--- a/libdockapp/src/wmgeneral.c
+++ b/libdockapp/src/wmgeneral.c
@@ -109,7 +109,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -277,7 +277,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/libdockapp/src/wmgeneral.h
+++ b/libdockapp/src/wmgeneral.h
@@ -72,7 +72,7 @@ extern Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmCalClock/Src/xutils.h
+++ b/wmCalClock/Src/xutils.h
@@ -31,7 +31,7 @@ extern int            DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int);
 void 		initXwindow(int, char **);

--- a/wmMatrix/xutils.h
+++ b/wmMatrix/xutils.h
@@ -22,7 +22,7 @@ int DisplayDepth;
 /*
  *   Function Prototypes
  */
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 void openXwindow(int, char **, char **, char *, int, int);
 void initXwindow(int, char **);

--- a/wmcalclockkbd/src/xutils.h
+++ b/wmcalclockkbd/src/xutils.h
@@ -28,7 +28,7 @@ extern int             DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int);
 void 		initXwindow(int, char **);

--- a/wmcube/wmgeneral/wmgeneral.c
+++ b/wmcube/wmgeneral/wmgeneral.c
@@ -89,7 +89,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -251,7 +251,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmcube/wmgeneral/wmgeneral.h
+++ b/wmcube/wmgeneral/wmgeneral.h
@@ -42,7 +42,7 @@ Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmdonkeymon/wmgeneral/wmgeneral.c
+++ b/wmdonkeymon/wmgeneral/wmgeneral.c
@@ -73,7 +73,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -200,7 +200,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmdonkeymon/wmgeneral/wmgeneral.h
+++ b/wmdonkeymon/wmgeneral/wmgeneral.h
@@ -34,7 +34,7 @@ Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 void DelMouseRegion(int index);
 int CheckMouseRegion(int x, int y);
 

--- a/wmglobe/src/wmglobe.h
+++ b/wmglobe/src/wmglobe.h
@@ -165,7 +165,7 @@ MY_EXTERN int stable;
 /****************************************************************/
 int main(int argc, char *argv[]);
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 void RedrawWindowXYWH(int x, int y, int w, int h);
 void set_defaults();

--- a/wmglobe/src/wmgutil.c
+++ b/wmglobe/src/wmgutil.c
@@ -690,7 +690,7 @@ void RedrawWindowXYWH(int x, int y, int w, int h)
 
 
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom)
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom)
 {
     if (index < MAX_MOUSE_REGION) {
 	mouse_region[index].enable = 1;

--- a/wmgrabimage/wmgeneral/wmgeneral.c
+++ b/wmgrabimage/wmgeneral/wmgeneral.c
@@ -70,7 +70,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -195,7 +195,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmgrabimage/wmgeneral/wmgeneral.h
+++ b/wmgrabimage/wmgeneral/wmgeneral.h
@@ -38,7 +38,7 @@ XpmIcon         wmgen;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmifinfo/xutils.h
+++ b/wmifinfo/xutils.h
@@ -31,7 +31,7 @@ extern int             DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int, char *, char *, char *, char *,char *);
 void 		initXwindow(int, char **);

--- a/wmjiface/src/xutils/xutils.h
+++ b/wmjiface/src/xutils/xutils.h
@@ -31,7 +31,7 @@ int             DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int, char *, char *, char *, char *,char *);
 void 		initXwindow(int, char **);

--- a/wmjmail/src/xutils/xutils.h
+++ b/wmjmail/src/xutils/xutils.h
@@ -31,7 +31,7 @@ int             DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int, char *, char *, char *, char *,char *);
 void 		initXwindow(int, char **);

--- a/wmmoonclock/src/xutils.h
+++ b/wmmoonclock/src/xutils.h
@@ -33,7 +33,7 @@ extern int             DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int, char *, char *, char *);
 void 		initXwindow(int, char **);

--- a/wmmp3/wmgeneral.c
+++ b/wmmp3/wmgeneral.c
@@ -89,7 +89,7 @@ MOUSE_REGION mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 void PutPixel(int, int, int);
 int GetPixel(int, int);
@@ -264,7 +264,7 @@ void RedrawWindowXY(int x, int y)
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom)
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom)
 {
 
 	if (index < MAX_MOUSE_REGION) {

--- a/wmmp3/wmgeneral.h
+++ b/wmmp3/wmgeneral.h
@@ -50,7 +50,7 @@ XpmIcon wmfont;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmpower/src/dockapp/dockapp.c
+++ b/wmpower/src/dockapp/dockapp.c
@@ -74,7 +74,7 @@ MOUSE_REGION mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -199,7 +199,7 @@ void RedrawWindowXY(int x, int y)
 |* AddMouseRegion                                                              *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom)
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom)
 {
 	if (index < MAX_MOUSE_REGION)
 	{

--- a/wmpower/src/dockapp/dockapp.h
+++ b/wmpower/src/dockapp/dockapp.h
@@ -34,7 +34,7 @@ Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmthemech/src/wmgeneral.c
+++ b/wmthemech/src/wmgeneral.c
@@ -72,7 +72,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -197,7 +197,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmthemech/src/wmgeneral.h
+++ b/wmthemech/src/wmgeneral.h
@@ -38,7 +38,7 @@ XpmIcon         wmgen;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmthrottle/src/mouse_regions.c
+++ b/wmthrottle/src/mouse_regions.c
@@ -86,7 +86,7 @@ MOUSE_REGION    mouse_region[MAX_MOUSE_REGION];
 |* AddMouseRegion                                                             *|
 \******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
     if (index < MAX_MOUSE_REGION) {
         mouse_region[index].enable = 1;

--- a/wmthrottle/src/mouse_regions.h
+++ b/wmthrottle/src/mouse_regions.h
@@ -11,7 +11,7 @@
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 void EnableMouseRegion(int index);
 void DisableMouseRegion(int index);

--- a/wmtunlo/docklib.c
+++ b/wmtunlo/docklib.c
@@ -334,7 +334,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -459,7 +459,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmtunlo/docklib.h
+++ b/wmtunlo/docklib.h
@@ -92,7 +92,7 @@ Window		iconwin, win;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmtv/src/wmgeneral/wmgeneral.c
+++ b/wmtv/src/wmgeneral/wmgeneral.c
@@ -98,7 +98,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -191,7 +191,7 @@ void RedrawWindowXYWH(int x, int y, int w, int h) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmtv/src/wmgeneral/wmgeneral.h
+++ b/wmtv/src/wmgeneral/wmgeneral.h
@@ -42,7 +42,7 @@ extern Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);

--- a/wmwork/src/wmgeneral.c
+++ b/wmwork/src/wmgeneral.c
@@ -107,7 +107,7 @@ MOUSE_REGION	mouse_region[MAX_MOUSE_REGION];
 static void GetXPM(XpmIcon *, char **);
 static Pixel GetColor(char *);
 void RedrawWindow(void);
-void AddMouseRegion(int, int, int, int, int);
+void AddMouseRegion(unsigned, int, int, int, int);
 int CheckMouseRegion(int, int);
 
 /*******************************************************************************\
@@ -269,7 +269,7 @@ void RedrawWindowXY(int x, int y) {
 |* AddMouseRegion															   *|
 \*******************************************************************************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom) {
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom) {
 
 	if (index < MAX_MOUSE_REGION) {
 		mouse_region[index].enable = 1;

--- a/wmwork/src/wmgeneral.h
+++ b/wmwork/src/wmgeneral.h
@@ -42,7 +42,7 @@ Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void initXwindow(char *display_name);

--- a/wmxss/Src/xutils.h
+++ b/wmxss/Src/xutils.h
@@ -31,7 +31,7 @@ int             DisplayDepth;
 /*
  *   Function Prototypes
  */
-void 		AddMouseRegion(int, int, int, int, int);
+void 		AddMouseRegion(unsigned, int, int, int, int);
 int  		CheckMouseRegion(int, int);
 void 		openXwindow(int, char **, char **, char *, int, int);
 void 		initXwindow(int, char **);

--- a/yawmppp/src/dockapp/wmgeneral.c
+++ b/yawmppp/src/dockapp/wmgeneral.c
@@ -64,7 +64,7 @@ MOUSE_REGION mouse_region[MAX_MOUSE_REGION];
 static void GetXPM (XpmIcon *, char **);
 static Pixel GetColor (char *);
 void RedrawWindow (void);
-void AddMouseRegion (int, int, int, int, int);
+void AddMouseRegion (unsigned, int, int, int, int);
 int CheckMouseRegion (int, int);
 
 static void
@@ -148,7 +148,7 @@ RedrawWindowXY (int x, int y)
 }
 
 void
-AddMouseRegion (int index, int left, int top, int right, int bottom)
+AddMouseRegion (unsigned index, int left, int top, int right, int bottom)
 {
 
     if (index < MAX_MOUSE_REGION)

--- a/yawmppp/src/dockapp/wmgeneral.h
+++ b/yawmppp/src/dockapp/wmgeneral.h
@@ -27,7 +27,7 @@ Display		*display;
  /* Function Prototypes */
 /***********************/
 
-void AddMouseRegion(int index, int left, int top, int right, int bottom);
+void AddMouseRegion(unsigned index, int left, int top, int right, int bottom);
 int CheckMouseRegion(int x, int y);
 
 void openXwindow(int argc, char *argv[], char **, char *, int, int);


### PR DESCRIPTION
This was previously already done for wmbiff/wmgeneral: the index argument is used as an index into an array, and is always only tested to be below the upper bound. Passing in a negative value would pass that test, and would result in an out-of-bounds access. All dockapps appear to get that right, but libdockapp could see this violated by a (future) user.