### PR TITLE
Update external URLs for some dockapps

### DIFF
--- a/_posts/1970-01-01-cdmon.md
+++ b/_posts/1970-01-01-cdmon.md
@@ -3,7 +3,7 @@ layout: dockapp
 title: cdmon
 permalink: cdmon
 hosted: 0
-website: http://download.zenwalk.org/people/jp/dockapps/
+website: http://download.zenwalk.org/x86_64/people/jp/dockapps/
 dockapps: 237
 images:
  - cdmon-041.gif

--- a/_posts/1970-01-01-devmon.md
+++ b/_posts/1970-01-01-devmon.md
@@ -3,7 +3,7 @@ layout: dockapp
 title: devmon
 permalink: devmon
 hosted: 0
-website: http://download.zenwalk.org/people/jp/dockapps/
+website: http://download.zenwalk.org/x86_64/people/jp/dockapps/
 dockapps: 231
 images:
  - devmon-1.5.png

--- a/_posts/1970-01-01-minicontrol.md
+++ b/_posts/1970-01-01-minicontrol.md
@@ -3,7 +3,7 @@ layout: dockapp
 title: minicontrol
 permalink: minicontrol
 hosted: 0
-website: http://download.zenwalk.org/people/jp/dockapps/
+website: http://download.zenwalk.org/x86_64/people/jp/dockapps/
 dockapps: 238
 images:
  - minicontrol.gif

--- a/_posts/1970-01-01-minidock.md
+++ b/_posts/1970-01-01-minidock.md
@@ -3,7 +3,7 @@ layout: dockapp
 title: minidock
 permalink: minidock
 hosted: 0
-website: http://download.zenwalk.org/people/jp/dockapps/
+website: http://download.zenwalk.org/x86_64/people/jp/dockapps/
 dockapps: 224
 images:
  - minidock.png

--- a/_posts/1970-01-01-wmtrash.md
+++ b/_posts/1970-01-01-wmtrash.md
@@ -3,7 +3,7 @@ layout: dockapp
 title: wmtrash
 permalink: wmtrash
 hosted: 0
-website: http://download.zenwalk.org/people/jp/dockapps/
+website: http://download.zenwalk.org/x86_64/people/jp/dockapps/
 dockapps: 266
 images:
  - wmtrash.gif


### PR DESCRIPTION
Update external URLs for the following dockapps:
* cdmon
* devmon
* minicontrol
* minidock
* wmtrash